### PR TITLE
Fix duplicating the namespace when using hydration block

### DIFF
--- a/cache_store_redis/lib/cache_store_redis.rb
+++ b/cache_store_redis/lib/cache_store_redis.rb
@@ -150,7 +150,7 @@ class RedisCacheStore
 
     if value.nil? && block_given?
       value = yield
-      set(k, value, expires_in)
+      set(key, value, expires_in)
     end
 
     value

--- a/cache_store_redis/spec/cache_store_redis_spec.rb
+++ b/cache_store_redis/spec/cache_store_redis_spec.rb
@@ -13,6 +13,10 @@ describe RedisCacheStore do
     @cache_store.configure(url: 'redis://redis:6379')
   end
 
+  after :each do
+    @cache_store.with_client &:flushdb
+  end
+
   describe "#set" do
     it 'should add a string to the cache store and retrieve it' do
 
@@ -96,6 +100,20 @@ describe RedisCacheStore do
           expect(@cache_store.get(key)).to eq(new_value)
         end
       end
+    end
+  end
+
+  describe '#get' do
+
+    let(:value) { 'value' }
+    let(:key) { 'getkey' }
+
+    it 'runs the hyrdation block when the value is not in the cache' do
+      v = @cache_store.get(key) do
+        value
+      end
+
+      expect(@cache_store.get(key)).to eq v
     end
   end
 


### PR DESCRIPTION
When using the hydration block on `#get` the namespace was being duplicated on the key. 