### PR TITLE
Fix issue parsing empty string

### DIFF
--- a/cache_store_redis/lib/cache_store_redis.rb
+++ b/cache_store_redis/lib/cache_store_redis.rb
@@ -146,7 +146,11 @@ class RedisCacheStore
       client.get(k)
     end
 
-    value = deserialize(value) unless value.nil?
+    if !value.nil? && value.delete('\"').strip.empty?
+      value = value.delete('\"')
+    else
+      value = deserialize(value) unless value.nil?
+    end
 
     if value.nil? && block_given?
       value = yield

--- a/cache_store_redis/spec/cache_store_redis_spec.rb
+++ b/cache_store_redis/spec/cache_store_redis_spec.rb
@@ -104,7 +104,6 @@ describe RedisCacheStore do
   end
 
   describe '#get' do
-
     let(:value) { 'value' }
     let(:key) { 'getkey' }
 
@@ -114,6 +113,19 @@ describe RedisCacheStore do
       end
 
       expect(@cache_store.get(key)).to eq v
+    end
+
+    context 'when the value in the store is empty string' do
+      let(:value) { '' }
+
+      it 'does not attempt to deserialize' do
+        v = @cache_store.get(key) do
+          value
+        end
+
+        expect(subject).to_not receive(:deserialize)
+        expect(@cache_store.get(key)).to eq v
+      end
     end
   end
 


### PR DESCRIPTION
On the version of `oj` we're using in the services, we'll get a parse
error when sending an empty string to `Oj.load`, and we've been seeing
this in pre-prod since v0.5.1 as previously we were getting the cache
key name wrong by duplicating namespace.

We now check for an empty string, and return that back without
deserializing.

Some additional info about oj handling empty string.

```
pry(main)> Oj::VERSION
=> "3.2.0"
pry(main)> Oj.load("")
EncodingError: An empty string is not a valid JSON string.
```

version being used in `cache_store_redis` tests
```
pry(#<RedisCacheStore>)> Oj.load('')
=> nil
pry(#<RedisCacheStore>)> Oj.load("\"\"")
=> ""
pry(#<RedisCacheStore>)> Oj.load("\" \"")
=> " "
pry(#<RedisCacheStore>)> Oj::VERSION
=> "2.15.0"
```

latest version
```
pry(main)> Oj.load("")
=> nil
pry(main)> Oj::VERSION
=> "3.3.10"```
```

https://github.com/ohler55/oj/issues/435