### PR TITLE
Release v0.5.2

### DIFF
--- a/cache_store_redis/lib/cache_store_redis/version.rb
+++ b/cache_store_redis/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
Fixes issue whereby we were trying to parse an empty string, which raises an exception in some versions of `Oj`.