### PR TITLE
Bugfix - Empty string issue

### DIFF
--- a/cache_store_redis/lib/cache_store_redis.rb
+++ b/cache_store_redis/lib/cache_store_redis.rb
@@ -116,7 +116,7 @@ class RedisCacheStore
   def set(key, value, expires_in = 0)
     k = build_key(key)
 
-    v = if value.nil?
+    v = if value.nil? || (value.is_a?(String) && value.empty?)
           nil
         else
           serialize(value)
@@ -147,7 +147,7 @@ class RedisCacheStore
     end
 
     if !value.nil? && value.delete('\"').strip.empty?
-      value = value.delete('\"')
+      value = nil
     else
       value = deserialize(value) unless value.nil?
     end

--- a/cache_store_redis/lib/cache_store_redis.rb
+++ b/cache_store_redis/lib/cache_store_redis.rb
@@ -116,7 +116,7 @@ class RedisCacheStore
   def set(key, value, expires_in = 0)
     k = build_key(key)
 
-    v = if value.nil? || (value.is_a?(String) && value.empty?)
+    v = if value.nil? || (value.is_a?(String) && value.strip.empty?)
           nil
         else
           serialize(value)

--- a/cache_store_redis/lib/cache_store_redis/version.rb
+++ b/cache_store_redis/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/cache_store_redis/spec/cache_store_redis_spec.rb
+++ b/cache_store_redis/spec/cache_store_redis_spec.rb
@@ -119,12 +119,9 @@ describe RedisCacheStore do
       let(:value) { '' }
 
       it 'does not attempt to deserialize' do
-        v = @cache_store.get(key) do
-          value
-        end
-
+        @cache_store.set(key, value)
         expect(subject).to_not receive(:deserialize)
-        expect(@cache_store.get(key)).to eq v
+        expect(@cache_store.get(key)).to be nil
       end
     end
   end


### PR DESCRIPTION
Resolved bug caused by empty strings during set/get preventing hydration block from executing.