### PR TITLE
added cleanup code to resolve bug with jruby

### DIFF
--- a/cache_store_redis/lib/cache_store_redis.rb
+++ b/cache_store_redis/lib/cache_store_redis.rb
@@ -146,7 +146,7 @@ class RedisCacheStore
       client.get(k)
     end
 
-    if !value.nil? && value.delete('\"').strip.empty?
+    if !value.nil? && value.strip.empty?
       value = nil
     else
       value = deserialize(value) unless value.nil?

--- a/cache_store_redis/lib/cache_store_redis/version.rb
+++ b/cache_store_redis/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 end

--- a/cache_store_redis/script/docker-compose.yml
+++ b/cache_store_redis/script/docker-compose.yml
@@ -14,7 +14,7 @@ testrunner:
     - redis
 
 testrunner2:
-  image: 522104923602.dkr.ecr.eu-west-1.amazonaws.com/sageone/jruby:20170623
+  image: 522104923602.dkr.ecr.eu-west-1.amazonaws.com/sageone/jruby:20171218
   container_name: testrunner_jruby
   command: sh -c "while true; do echo 'Container is running..'; sleep 5; done"
   volumes:

--- a/cache_store_redis/spec/cache_store_redis_spec.rb
+++ b/cache_store_redis/spec/cache_store_redis_spec.rb
@@ -62,6 +62,10 @@ describe RedisCacheStore do
       expect(v.text).to eq('abc123')
       expect(v.numeric).to eq(123)
 
+      v2 = @cache_store.get(key)
+      expect(v2.class).to eq(TestObject)
+      expect(v2.text).to eq('abc123')
+      expect(v2.numeric).to eq(123)
     end
 
     context 'when set value has expired' do


### PR DESCRIPTION
Removed `.delete` in get call as no longer required due to `set` method preventing empty strings from being serialised. This resolved a bug within jruby.