### PR TITLE
Optimise mock cache store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+*.swp

--- a/cache_store_base/lib/cache_store.rb
+++ b/cache_store_base/lib/cache_store.rb
@@ -1,53 +1,50 @@
-require "cache_store/version"
+# frozen_string_literal: true
+
+require 'cache_store/version'
 require 'date'
 require 'time'
-#This class is used to define the contract that CacheStore implementations must adhere to.
-class CacheStoreContract
 
+# Defines the contract that CacheStore implementations must adhere to.
+class CacheStoreContract
   def initialize(namespace = '')
-    @namespace = namespace
   end
 
-  # This method is called to set a value within this cache store by its key.
+  # Sets a value within this cache store by its key.
   #
   # @param [String] This is the unique key to reference the value being set within this cache store.
   # @param [Object] This is the value to set within this cache store.
   # @param [Integer] This is the number of seconds from the current time that this value should expire.
   def set(key, value, expires_in = 0)
-
   end
 
-  # This method is called to get a value from this cache store by its unique key.
+  # Gets a value from this cache store by its unique key.
   #
   # @param [String] This is the unique key to reference the value to fetch from within this cache store.
   # @param [Integer] This is the number of seconds from the current time that this value should expire. (This is used in conjunction with the block to hydrate the cache key if it is empty.)
   # @param [Block] This block is provided to hydrate this cache store with the value for the request key when it is not found.
   def get(key, expires_in = 0, &block)
-
   end
 
-  # This method is called to remove a value from this cache store by its unique key.
+  # Removes a value from this cache store by its unique key.
   #
   # @param [String] This is the unique key to reference the value to remove from this cache store.
   def remove(key)
-
   end
 
-  # This method is called to check if a value exists within this cache store for a specific key.
+  # Checks if a value exists within this cache store for a specific key.
   #
   # @param [String] This is the unique key to reference the value to check for within this cache store.
   def exist?(key)
-
   end
 end
 
-# This class implements a local in-memory cache store.
+# Implements a local in-memory cache store.
 class LocalCacheStore
   def initialize(_namespace = nil)
     @store = {}
   end
 
-  # Store a value in this cache store by its key.
+  # Stores a value in this cache store by its key.
   #
   # @param key [String] The unique key to reference the value being set.
   # @param value [Object] The value to store.
@@ -59,7 +56,7 @@ class LocalCacheStore
     @store.store(key, {value: value, expires: expires})
   end
 
-  # This method is called to get a value from this cache store by its unique key.
+  # Gets a value from this cache store by its unique key.
   #
   # @param key [String] Unique key to reference the value to fetch from within this cache store.
   # @param &block [Block] This block is provided to populate this cache store with the value for the request key when it is not found.
@@ -86,14 +83,14 @@ class LocalCacheStore
     end
   end
 
-  # This method is called to remove a value from this cache store by its unique key.
+  # Removes a value from this cache store by its unique key.
   #
   # @param key [String] The unique key to remove from this cache store.
   def remove(key)
     @store.delete key
   end
 
-  # This method is called to check if a value exists within this cache store for a specific key.
+  # Checks if a value exists within this cache store for a specific key.
   #
   # @param key [String] The unique key to reference the value to check for within this cache store.
   # @return [Boolean] True or False to specify if the key exists in the cache store.


### PR DESCRIPTION
The in-memory mock cache store has been refactored to use a hash as its backing store rather than an array. This optimisation is required for the change data capture project which makes extensive use of the mock in its tests.